### PR TITLE
Aaf 109 families filter

### DIFF
--- a/server/routes/__tests__/FamilyApi.test.js
+++ b/server/routes/__tests__/FamilyApi.test.js
@@ -1,0 +1,54 @@
+const request = require('supertest');
+const express = require('express');
+const app = express();
+const apiRoutes = require('../../routes/api');
+const Family = require('../../models/family');
+
+const FAMILY_ENDPOINT = '/api/families';
+
+app.use('/api', apiRoutes);
+
+describe('Test /api/families,', () => {
+  describe('Test 200 responses', () => {
+    // TODO: this fails still
+    it.skip('Should return 200 if no filter is passed', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query()
+        .then(response => {
+          expect(response.statusCode).toBe(200);
+        });
+    });
+
+    it('Should return 200 if filter and value parameters are present', async () => {
+      // Find a family and use the ID
+      const familiesList = await Family.find()
+        .then(res => res)
+        .catch(err => console.error(err));
+
+      const familyId = familiesList[0]._id;
+
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({
+          filter: '_id',
+          value: familyId,
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(200);
+        });
+    });
+
+    // TODO: this fails still
+    it.skip('Should return 200 if valid filter is passed', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query()
+        .then(response => {
+          expect(response.statusCode).toBe(200);
+        });
+    });
+  });
+
+  describe('Test 400 responses', () => {});
+});

--- a/server/routes/__tests__/FamilyApi.test.js
+++ b/server/routes/__tests__/FamilyApi.test.js
@@ -10,8 +10,7 @@ app.use('/api', apiRoutes);
 
 describe('Test /api/families,', () => {
   describe('Test 200 responses', () => {
-    // TODO: this fails still
-    it.skip('Should return 200 if no filter is passed', () => {
+    it('Should return 200 if no filter is passed', () => {
       return request(app)
         .get(FAMILY_ENDPOINT)
         .query()
@@ -38,17 +37,24 @@ describe('Test /api/families,', () => {
           expect(response.statusCode).toBe(200);
         });
     });
+  });
 
-    // TODO: this fails still
-    it.skip('Should return 200 if valid filter is passed', () => {
+  describe('Test 400 responses', () => {
+    it('Should return 400 if missing value query', () => {
       return request(app)
         .get(FAMILY_ENDPOINT)
-        .query()
+        .query({ query: '_id' })
         .then(response => {
-          expect(response.statusCode).toBe(200);
+          expect(response.statusCode).toBe(400);
+        });
+    });
+    it('Should return 400 if missing filter query', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ value: 'test' })
+        .then(response => {
+          expect(response.statusCode).toBe(400);
         });
     });
   });
-
-  describe('Test 400 responses', () => {});
 });

--- a/server/routes/__tests__/FamilyApi.test.js
+++ b/server/routes/__tests__/FamilyApi.test.js
@@ -37,23 +37,85 @@ describe('Test /api/families,', () => {
           expect(response.statusCode).toBe(200);
         });
     });
+
+    it('Should return an object with property "families" as an array if valid queries present', async () => {
+      // Find a family and use the ID
+      const familiesList = await Family.find()
+        .then(res => res)
+        .catch(err => console.error(err));
+
+      const familyId = familiesList[0]._id;
+
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({
+          filter: '_id',
+          value: familyId,
+        })
+        .then(response => {
+          expect.objectContaining({
+            families: expect.any(Array),
+          });
+        });
+    });
   });
 
   describe('Test 400 responses', () => {
     it('Should return 400 if missing value query', () => {
       return request(app)
         .get(FAMILY_ENDPOINT)
-        .query({ query: '_id' })
+        .query({ filter: '_id' })
         .then(response => {
           expect(response.statusCode).toBe(400);
         });
     });
+
     it('Should return 400 if missing filter query', () => {
       return request(app)
         .get(FAMILY_ENDPOINT)
         .query({ value: 'test' })
         .then(response => {
           expect(response.statusCode).toBe(400);
+        });
+    });
+
+    it('Should return 400 if queries besides "filter" or "value" are passed', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ test: 'not valid', bar: 'foo' })
+        .then(response => {
+          expect(response.statusCode).toBe(400);
+        });
+    });
+
+    it('Should return an error message if missing value query', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ filter: '_id' })
+        .then(response => {
+          expect(response.body.message).toBe(
+            'Received 1 parameter(s) but expected 2.'
+          );
+        });
+    });
+
+    it('Should return an error message if missing filter query', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ value: 'test' })
+        .then(response => {
+          expect(response.body.message).toBe(
+            'Received 1 parameter(s) but expected 2.'
+          );
+        });
+    });
+
+    it('Should return an error message if query besides "filter"/"value" are passed', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ test: 'not valid', bar: 'foo' })
+        .then(response => {
+          expect(response.body.message).toBe('Invalid parameters supplied.');
         });
     });
   });

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -145,44 +145,52 @@ routes.get('/wishlist/:familyId', (req, res) => {
   }
 });
 
+// This route will only accept 0 query params or exactly 2: filter and value
 routes.get('/families', (req, res) => {
   const { filter, value } = req.query;
   const queryKeys = Object.keys(req.query);
+  console.log(`query: ${req.query}`);
+  console.log(`querykeys: ${queryKeys}`);
 
   if (queryKeys.length === 0) {
-    const families = Family.find();
+    const query = Family.find();
 
-    res.status(200).json({ families });
-  }
-
-  // Throw 400 if incorrect number of parameters received
-  if (queryKeys.length !== 2) {
+    query
+      .exec()
+      .then(families => {
+        res.status(200).json({ families });
+      })
+      .catch(err => {
+        res.status(500).json({
+          message: err,
+        });
+      });
+  } else if (queryKeys.length !== 2) {
+    // Throw 400 if incorrect number of parameters received
     res.status(400).json({
       message: `Received ${queryKeys.length} parameters but expected 2.`,
     });
-  }
-
-  // Throw 400 if there are queries that are not filter/value
-  if (!filter || !value) {
+  } else if (!filter || !value) {
+    // Throw 400 if there are queries that are not filter/value
     res.status(400).json({
       message: 'Invalid parameters supplied',
     });
+  } else {
+    const query = Family.find({ filter: value });
+
+    query
+      .exec()
+      .then(families => {
+        res.status(200).json({
+          families,
+        });
+      })
+      .catch(err => {
+        res.status(500).json({
+          message: err,
+        });
+      });
   }
-
-  const query = Family.find({ filter: value });
-
-  query
-    .exec()
-    .then(families => {
-      res.status(200).json({
-        families,
-      });
-    })
-    .catch(err => {
-      res.status(500).json({
-        message: err,
-      });
-    });
 });
 
 module.exports = routes;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -139,7 +139,29 @@ routes.get('/wishlist/:familyId', (req, res) => {
         }
       });
   }
+
+routes.get('/families', (req, res) => {
+  const { filter, value } = req.query;
+  let query;
+
+  if (!filter || !value) {
+    query = Family.find();
+  } else {
+    query = Family.find()
+      .where(filter)
+      .equals(value);
+  }
+
+  query
+    .exec()
+    .then(families => {
+      res.status(200).json({ families });
+    })
+    .catch(err => {
+      res.status(500).json({
+        message: err,
+      });
+    });
 });
 
 module.exports = routes;
-

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -115,4 +115,28 @@ routes.get('/pairing/paired', (req, res) => {
   });
 });
 
+routes.get('/families', (req, res) => {
+  const { filter, value } = req.query;
+  let query;
+
+  if (!filter || !value) {
+    query = Family.find();
+  } else {
+    query = Family.find()
+      .where(filter)
+      .equals(value);
+  }
+
+  query
+    .exec()
+    .then(families => {
+      res.status(200).json({ families });
+    })
+    .catch(err => {
+      res.status(500).json({
+        message: err,
+      });
+    });
+});
+
 module.exports = routes;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -149,8 +149,6 @@ routes.get('/wishlist/:familyId', (req, res) => {
 routes.get('/families', (req, res) => {
   const { filter, value } = req.query;
   const queryKeys = Object.keys(req.query);
-  console.log(`query: ${req.query}`);
-  console.log(`querykeys: ${queryKeys}`);
 
   if (queryKeys.length === 0) {
     const query = Family.find();
@@ -168,12 +166,12 @@ routes.get('/families', (req, res) => {
   } else if (queryKeys.length !== 2) {
     // Throw 400 if incorrect number of parameters received
     res.status(400).json({
-      message: `Received ${queryKeys.length} parameters but expected 2.`,
+      message: `Received ${queryKeys.length} parameter(s) but expected 2.`,
     });
   } else if (!filter || !value) {
     // Throw 400 if there are queries that are not filter/value
     res.status(400).json({
-      message: 'Invalid parameters supplied',
+      message: 'Invalid parameters supplied.',
     });
   } else {
     const query = Family.find({ filter: value });


### PR DESCRIPTION
This route is expected to be used like so:

- `GET /api/families` with no queries returns list of all families
- `GET /api/families` passing `filter` and `value` will look up families with the provided filter and value and return an object with a property families, an array of the families.

- If you pass less than 2 or more than 2 query fields, the route throws 400.
- If you pass exactly 2 query fields but they are not `filter` or `value`, it will throw 400.
  - eg: `filter: foo` and `valu: bar` or `foo: bar` and `bar: foo`