### PR TITLE
Aaf 110 donors filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.4",
@@ -90,7 +90,7 @@
     "acorn": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha1-kRy1PgNoB88Pp3jcXTcPvYZCRtc=",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -217,7 +217,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -278,7 +278,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
@@ -1964,6 +1964,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2236,7 +2237,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "commondir": {
@@ -2425,7 +2426,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "content-type-parser": {
       "version": "1.0.2",
@@ -2561,7 +2562,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
             "hoek": "4.2.0"
           }
@@ -4465,6 +4466,542 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
@@ -4603,7 +5140,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -4668,7 +5205,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -4918,7 +5455,7 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -4935,7 +5472,7 @@
     "history": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
-      "integrity": "sha1-IrXH8xYzxbgCHH9KipVKwTnujVs=",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "requires": {
         "invariant": "2.2.2",
         "loose-envify": "1.3.1",
@@ -4958,7 +5495,7 @@
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "hoist-non-react-statics": {
       "version": "2.3.1",
@@ -4992,7 +5529,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "hpack.js": {
@@ -5191,7 +5728,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -7081,7 +7618,7 @@
     "js-base64": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-      "integrity": "sha1-p5qSNmY3K1gPjif1GEXG9+j7+68=",
+      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
       "dev": true
     },
     "js-tokens": {
@@ -7564,7 +8101,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -7804,7 +8341,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -8070,7 +8607,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
@@ -8323,6 +8860,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.0",
+            "fsevents": "1.2.4",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -8577,7 +9115,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -10126,7 +10664,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "2.0.6"
       }
@@ -10256,7 +10794,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -10416,7 +10954,7 @@
     "react-router": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
-      "integrity": "sha1-Yfez43cNrrJAYtrj7t7xsFQVWYY=",
+      "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
       "requires": {
         "history": "4.7.2",
         "hoist-non-react-statics": "2.3.1",
@@ -10440,7 +10978,7 @@
     "react-router-dom": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
-      "integrity": "sha1-yKgd863Fi7qKdngulGy9Tq5km40=",
+      "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
       "requires": {
         "history": "4.7.2",
         "invariant": "2.2.2",
@@ -10478,6 +11016,7 @@
         "extract-text-webpack-plugin": "3.0.2",
         "file-loader": "1.1.5",
         "fs-extra": "3.0.1",
+        "fsevents": "1.2.4",
         "html-webpack-plugin": "2.29.0",
         "jest": "20.0.4",
         "object-assign": "4.1.1",
@@ -11192,7 +11731,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -11351,7 +11890,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
@@ -11674,7 +12213,7 @@
     "resolve-pathname": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha1-fpriHtgV/WOrGJre7mTcgx7vqHk="
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -11710,7 +12249,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }
@@ -11768,7 +12307,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sane": {
       "version": "2.4.1",
@@ -11779,6 +12318,7 @@
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
+        "fsevents": "1.2.4",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -12122,7 +12662,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -12811,7 +13351,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -13936,7 +14476,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -13951,7 +14491,7 @@
     "value-equal": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
-      "integrity": "sha1-xb3S9U7gk8BIOdcc4uR1imiQq8c="
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -14535,7 +15075,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -6,18 +6,14 @@
   "scripts": {
     "build": "react-scripts build",
     "build-css": "node-sass-chokidar src/ -o src/devBuild",
-    "sass-lint":
-      "sass-lint ./src --config .sass-lint.yml 'src/**/*.scss' --verbose --ignore 'node_modules/**/*'",
+    "sass-lint": "sass-lint ./src --config .sass-lint.yml 'src/**/*.scss' --verbose --ignore 'node_modules/**/*'",
     "server": "nodemon server/app.js",
-    "start":
-      "concurrently --prefix \"[AAF]\" \"npm run watch-css\" \"npm run server\" \"react-scripts start\"",
-	"test:lint": "eslint ./",
+    "start": "concurrently --prefix \"[AAF]\" \"npm run watch-css\" \"npm run server\" \"react-scripts start\"",
+    "test:lint": "eslint ./",
     "test:react": "react-scripts test --env=jsdom",
     "test:api": "jest Api --notify --env=node --forceExit",
-    "test":
-      "concurrently 'npm run test:lint' 'npm run test:react' 'npm run test:api'",
-    "watch-css":
-      "npm run build-css && node-sass-chokidar src/ -o src/devBuild/ --watch --recursive"
+    "test": "concurrently 'npm run test:lint' 'npm run test:react' 'npm run test:api'",
+    "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/devBuild/ --watch --recursive"
   },
   "repository": {
     "type": "git",

--- a/server/controllers/donorController.js
+++ b/server/controllers/donorController.js
@@ -58,8 +58,14 @@ exports.filterBySingleValue = (req, res) => {
     query
       .exec()
       .then(donors => {
-        res.status(200).json({
-          donors,
+        if (!donors) {
+          return res.status(400).json({
+            message: 'No donors found.',
+          });
+        }
+
+        return res.status(200).json({
+          donors: [...donors],
         });
       })
       .catch(err => {

--- a/server/controllers/donorController.js
+++ b/server/controllers/donorController.js
@@ -4,7 +4,7 @@ exports.readWishList = (req, res) => {
   Donor.findOne({ id: req.params.id })
     .populate({
       path: matchedFamily,
-      populate: { path: wishlist }
+      populate: { path: wishlist },
     })
     .exec((err, wishlist) => {
       if (err) {
@@ -13,4 +13,59 @@ exports.readWishList = (req, res) => {
       }
       res.json(wishlist);
     });
+};
+
+exports.showAll = (req, res) => {
+  const queryKeys = Object.keys(req.query);
+
+  if (queryKeys.length === 0) {
+    const query = Donor.find();
+
+    query
+      .exec()
+      .then(donors => {
+        res.status(200).json({ donors });
+      })
+      .catch(err => {
+        res.status(500).json({ message: err });
+      });
+  } else {
+    // Throw 400 if incorrect number of parameters received
+    res.status(400).json({
+      message: `Received ${queryKeys.length} parameter(s) but expected 0.`,
+    });
+  }
+};
+
+exports.filterBySingleValue = (req, res) => {
+  const { value } = req.query;
+  const { filter } = req.params;
+  const queryKeys = Object.keys(req.query);
+
+  if (queryKeys.length !== 1) {
+    // Throw 400 if incorrect number of parameters received
+    res.status(400).json({
+      message: `Received ${queryKeys.length} parameter(s) but expected 1.`,
+    });
+  } else if (!filter || !value) {
+    // Throw 400 if there are queries that are not filter/value
+    res.status(400).json({
+      message: 'Invalid parameters supplied.',
+    });
+  } else {
+    const query = Donor.find({ filter: value });
+
+    query
+      .exec()
+      .then(donors => {
+        res.status(200).json({
+          donors,
+        });
+      })
+      .catch(err => {
+        res.status(500).json({
+          message: err,
+        });
+      });
+  }
 };

--- a/server/controllers/donorController.js
+++ b/server/controllers/donorController.js
@@ -1,4 +1,5 @@
 const Donor = require('../models/donor');
+const mongoose = require('mongoose');
 
 exports.readWishList = (req, res) => {
   Donor.findOne({ id: req.params.id })
@@ -47,13 +48,16 @@ exports.filterBySingleValue = (req, res) => {
     res.status(400).json({
       message: `Received ${queryKeys.length} parameter(s) but expected 1.`,
     });
-  } else if (!filter || !value) {
-    // Throw 400 if there are queries that are not filter/value
-    res.status(400).json({
-      message: 'Invalid parameters supplied.',
-    });
-  } else {
-    const query = Donor.find({ filter: value });
+  } else if (filter === '_id') {
+    const convertedId = mongoose.Types.ObjectId(value);
+    const isValidId = mongoose.Types.ObjectId.isValid(convertedId);
+    if (!isValidId) {
+      res.status(422).json({
+        message: 'Invalid objectId.',
+      });
+    }
+
+    const query = Donor.find(convertedId);
 
     query
       .exec()

--- a/server/routes/__tests__/DonorApi.test.js
+++ b/server/routes/__tests__/DonorApi.test.js
@@ -20,16 +20,9 @@ describe('Test /api/donors,', () => {
     });
 
     it('Should return an object with property "donors" as an array', async () => {
-      // Find a family and use the ID
-      const donorsList = await Donor.find()
-        .then(res => res)
-        .catch(err => console.error(err));
-
-      const donorId = donorsList[0]._id;
-
       return request(app)
         .get(DONOR_ENDPOINT)
-        .query({ filter: '_id', value: donorId })
+        .query()
         .then(response => {
           expect.objectContaining({ donors: expect.any(Array) });
         });
@@ -52,7 +45,7 @@ describe('Test /api/donors,', () => {
         .query({ filter: '_id', value: '123abc' })
         .then(response => {
           expect(response.body.message).toBe(
-            'Received 2 parameter(s) but expected 0.'
+            'Received 2 parameter(s) but expected 0.',
           );
         });
     });
@@ -72,7 +65,7 @@ describe('Test /api/donors/:filter', () => {
 
       return request(app)
         .get(DONOR_ENDPOINT + '/' + param)
-        .query({ value: donorId })
+        .query({ donorId })
         .then(response => {
           expect(response.statusCode).toBe(200);
         });
@@ -89,25 +82,37 @@ describe('Test /api/donors/:filter', () => {
 
       return request(app)
         .get(DONOR_ENDPOINT + '/' + param)
-        .query({ value: donorId })
+        .query({ donorId })
         .then(response => {
           expect.objectContaining({ donors: expect.any(Array) });
         });
     });
 
-    it.skip('Should return an object with property "donors" as an EMPTY array if value is not valid but filter is valid and nothign is found', async () => {
+    it('Should return 200 if filter is valid but value is invalid', async () => {
       const donorId = 111;
       const param = '_id';
 
       return request(app)
         .get(DONOR_ENDPOINT + '/' + param)
-        .query({ value: donorId })
+        .query({ donorId })
         .then(response => {
-          expect(response.donors).toHaveLength(0);
+          expect(response.statusCode).toBe(200);
         });
     });
 
-    it.skip('Should return an object with property "donors" as an EMPTY array if the filter is not valid but query is valid and nothing is not found', async () => {
+    it('Should return an object with property "donors" as an EMPTY array if query is not valid but filter is valid and nothing is found', async () => {
+      const donorId = 111;
+      const param = '_id';
+
+      return request(app)
+        .get(DONOR_ENDPOINT + '/' + param)
+        .query({ donorId })
+        .then(response => {
+          expect(response.body.donors).toHaveLength(0);
+        });
+    });
+
+    it('Should return an object with property "donors" as an EMPTY array if the filter is not valid but query is valid and nothing is not found', async () => {
       const donorsList = await Donor.find()
         .then(res => res)
         .catch(err => console.error(err));
@@ -117,9 +122,9 @@ describe('Test /api/donors/:filter', () => {
 
       return request(app)
         .get(DONOR_ENDPOINT + '/' + param)
-        .query({ value: donorId })
+        .query({ donorId })
         .then(response => {
-          expect(response.donors).toHaveLength(0);
+          expect(response.body.donors).toHaveLength(0);
         });
     });
   });

--- a/server/routes/__tests__/DonorApi.test.js
+++ b/server/routes/__tests__/DonorApi.test.js
@@ -1,0 +1,128 @@
+const request = require('supertest');
+const express = require('express');
+const app = express();
+const apiRoutes = require('../../routes/api');
+const Donor = require('../../models/family');
+
+const DONOR_ENDPOINT = '/api/donors';
+
+app.use('/api', apiRoutes);
+
+// Broken aka i haven't written the tests yet
+describe.skip('Test /api/donors,', () => {
+  describe('Test 200 responses', () => {
+    it('Should return 200 if no filter is passed', () => {
+      return request(app)
+        .get(DONOR_ENDPOINT)
+        .query()
+        .then(response => {
+          expect(response.statusCode).toBe(200);
+        });
+    });
+
+    it('Should return 200 if filter and value parameters are present', async () => {
+      // Find a family and use the ID
+      const donorsList = await Donor.find()
+        .then(res => res)
+        .catch(err => console.error(err));
+
+      const familyId = donorsList[0]._id;
+
+      return request(app)
+        .get(DONOR_ENDPOINT)
+        .query({
+          filter: '_id',
+          value: familyId,
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(200);
+        });
+    });
+
+    it('Should return an object with property "donors" as an array if valid queries present', async () => {
+      // Find a family and use the ID
+      const donorsList = await Donor.find()
+        .then(res => res)
+        .catch(err => console.error(err));
+
+      const familyId = donorsList[0]._id;
+
+      return request(app)
+        .get(DONOR_ENDPOINT)
+        .query({
+          filter: '_id',
+          value: familyId,
+        })
+        .then(response => {
+          expect.objectContaining({
+            donors: expect.any(Array),
+          });
+        });
+    });
+  });
+
+  describe('Test 400 responses', () => {
+    it('Should return 400 if missing value query', () => {
+      return request(app)
+        .get(DONOR_ENDPOINT)
+        .query({ filter: '_id' })
+        .then(response => {
+          expect(response.statusCode).toBe(400);
+        });
+    });
+
+    it('Should return 400 if missing filter query', () => {
+      return request(app)
+        .get(DONOR_ENDPOINT)
+        .query({ value: 'test' })
+        .then(response => {
+          expect(response.statusCode).toBe(400);
+        });
+    });
+
+    it('Should return 400 if queries besides "filter" or "value" are passed', () => {
+      return request(app)
+        .get(DONOR_ENDPOINT)
+        .query({ test: 'not valid', bar: 'foo' })
+        .then(response => {
+          expect(response.statusCode).toBe(400);
+        });
+    });
+
+    it('Should return an error message if missing value query', () => {
+      return request(app)
+        .get(DONOR_ENDPOINT)
+        .query({ filter: '_id' })
+        .then(response => {
+          expect(response.body.message).toBe(
+            'Received 1 parameter(s) but expected 2.'
+          );
+        });
+    });
+
+    it('Should return an error message if missing filter query', () => {
+      return request(app)
+        .get(DONOR_ENDPOINT)
+        .query({ value: 'test' })
+        .then(response => {
+          expect(response.body.message).toBe(
+            'Received 1 parameter(s) but expected 2.'
+          );
+        });
+    });
+
+    it('Should return an error message if query besides "filter"/"value" are passed', () => {
+      return request(app)
+        .get(DONOR_ENDPOINT)
+        .query({ test: 'not valid', bar: 'foo' })
+        .then(response => {
+          expect(response.body.message).toBe('Invalid parameters supplied.');
+        });
+    });
+  });
+});
+
+describe('Test /api/donors/:filter', () => {
+  describe('Test 200 responses', () => {});
+  describe('Test 400 responses', () => {});
+});

--- a/server/routes/__tests__/FamilyApi.test.js
+++ b/server/routes/__tests__/FamilyApi.test.js
@@ -1,0 +1,54 @@
+const request = require('supertest');
+const express = require('express');
+const app = express();
+const apiRoutes = require('../../routes/api');
+const Family = require('../../models/family');
+
+const FAMILY_ENDPOINT = '/api/families';
+
+app.use('/api', apiRoutes);
+
+describe('Test /api/families,', () => {
+  describe('Test 200 responses', () => {
+    // TODO: this fails still
+    it.skip('Should return 200 if no filter is passed', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query()
+        .then(response => {
+          expect(response.statusCode).toBe(200);
+        });
+    });
+
+    it('Should return 200 if filter and value parameters are present', async () => {
+      // Find a family and use the ID
+      const familiesList = await Family.find()
+        .then(res => res)
+        .catch(err => console.error(err));
+
+      const familyId = familiesList[0]._id;
+
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({
+          filter: '_id',
+          value: familyId,
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(200);
+        });
+    });
+
+    // TODO: this fails still
+    it.skip('Should return 200 if valid filter is passed', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query()
+        .then(response => {
+          expect(response.statusCode).toBe(200);
+        });
+    });
+  });
+
+  describe('Test 400 responses', () => {});
+});

--- a/server/routes/__tests__/FamilyApi.test.js
+++ b/server/routes/__tests__/FamilyApi.test.js
@@ -10,8 +10,7 @@ app.use('/api', apiRoutes);
 
 describe('Test /api/families,', () => {
   describe('Test 200 responses', () => {
-    // TODO: this fails still
-    it.skip('Should return 200 if no filter is passed', () => {
+    it('Should return 200 if no filter is passed', () => {
       return request(app)
         .get(FAMILY_ENDPOINT)
         .query()
@@ -38,17 +37,24 @@ describe('Test /api/families,', () => {
           expect(response.statusCode).toBe(200);
         });
     });
+  });
 
-    // TODO: this fails still
-    it.skip('Should return 200 if valid filter is passed', () => {
+  describe('Test 400 responses', () => {
+    it('Should return 400 if missing value query', () => {
       return request(app)
         .get(FAMILY_ENDPOINT)
-        .query()
+        .query({ query: '_id' })
         .then(response => {
-          expect(response.statusCode).toBe(200);
+          expect(response.statusCode).toBe(400);
+        });
+    });
+    it('Should return 400 if missing filter query', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ value: 'test' })
+        .then(response => {
+          expect(response.statusCode).toBe(400);
         });
     });
   });
-
-  describe('Test 400 responses', () => {});
 });

--- a/server/routes/__tests__/FamilyApi.test.js
+++ b/server/routes/__tests__/FamilyApi.test.js
@@ -37,23 +37,85 @@ describe('Test /api/families,', () => {
           expect(response.statusCode).toBe(200);
         });
     });
+
+    it('Should return an object with property "families" as an array if valid queries present', async () => {
+      // Find a family and use the ID
+      const familiesList = await Family.find()
+        .then(res => res)
+        .catch(err => console.error(err));
+
+      const familyId = familiesList[0]._id;
+
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({
+          filter: '_id',
+          value: familyId,
+        })
+        .then(response => {
+          expect.objectContaining({
+            families: expect.any(Array),
+          });
+        });
+    });
   });
 
   describe('Test 400 responses', () => {
     it('Should return 400 if missing value query', () => {
       return request(app)
         .get(FAMILY_ENDPOINT)
-        .query({ query: '_id' })
+        .query({ filter: '_id' })
         .then(response => {
           expect(response.statusCode).toBe(400);
         });
     });
+
     it('Should return 400 if missing filter query', () => {
       return request(app)
         .get(FAMILY_ENDPOINT)
         .query({ value: 'test' })
         .then(response => {
           expect(response.statusCode).toBe(400);
+        });
+    });
+
+    it('Should return 400 if queries besides "filter" or "value" are passed', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ test: 'not valid', bar: 'foo' })
+        .then(response => {
+          expect(response.statusCode).toBe(400);
+        });
+    });
+
+    it('Should return an error message if missing value query', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ filter: '_id' })
+        .then(response => {
+          expect(response.body.message).toBe(
+            'Received 1 parameter(s) but expected 2.'
+          );
+        });
+    });
+
+    it('Should return an error message if missing filter query', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ value: 'test' })
+        .then(response => {
+          expect(response.body.message).toBe(
+            'Received 1 parameter(s) but expected 2.'
+          );
+        });
+    });
+
+    it('Should return an error message if query besides "filter"/"value" are passed', () => {
+      return request(app)
+        .get(FAMILY_ENDPOINT)
+        .query({ test: 'not valid', bar: 'foo' })
+        .then(response => {
+          expect(response.body.message).toBe('Invalid parameters supplied.');
         });
     });
   });

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -145,44 +145,52 @@ routes.get('/wishlist/:familyId', (req, res) => {
   }
 });
 
+// This route will only accept 0 query params or exactly 2: filter and value
 routes.get('/families', (req, res) => {
   const { filter, value } = req.query;
   const queryKeys = Object.keys(req.query);
+  console.log(`query: ${req.query}`);
+  console.log(`querykeys: ${queryKeys}`);
 
   if (queryKeys.length === 0) {
-    const families = Family.find();
+    const query = Family.find();
 
-    res.status(200).json({ families });
-  }
-
-  // Throw 400 if incorrect number of parameters received
-  if (queryKeys.length !== 2) {
+    query
+      .exec()
+      .then(families => {
+        res.status(200).json({ families });
+      })
+      .catch(err => {
+        res.status(500).json({
+          message: err,
+        });
+      });
+  } else if (queryKeys.length !== 2) {
+    // Throw 400 if incorrect number of parameters received
     res.status(400).json({
       message: `Received ${queryKeys.length} parameters but expected 2.`,
     });
-  }
-
-  // Throw 400 if there are queries that are not filter/value
-  if (!filter || !value) {
+  } else if (!filter || !value) {
+    // Throw 400 if there are queries that are not filter/value
     res.status(400).json({
       message: 'Invalid parameters supplied',
     });
+  } else {
+    const query = Family.find({ filter: value });
+
+    query
+      .exec()
+      .then(families => {
+        res.status(200).json({
+          families,
+        });
+      })
+      .catch(err => {
+        res.status(500).json({
+          message: err,
+        });
+      });
   }
-
-  const query = Family.find({ filter: value });
-
-  query
-    .exec()
-    .then(families => {
-      res.status(200).json({
-        families,
-      });
-    })
-    .catch(err => {
-      res.status(500).json({
-        message: err,
-      });
-    });
 });
 
 module.exports = routes;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -139,7 +139,29 @@ routes.get('/wishlist/:familyId', (req, res) => {
         }
       });
   }
+
+routes.get('/families', (req, res) => {
+  const { filter, value } = req.query;
+  let query;
+
+  if (!filter || !value) {
+    query = Family.find();
+  } else {
+    query = Family.find()
+      .where(filter)
+      .equals(value);
+  }
+
+  query
+    .exec()
+    .then(families => {
+      res.status(200).json({ families });
+    })
+    .catch(err => {
+      res.status(500).json({
+        message: err,
+      });
+    });
 });
 
 module.exports = routes;
-

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -115,4 +115,28 @@ routes.get('/pairing/paired', (req, res) => {
   });
 });
 
+routes.get('/families', (req, res) => {
+  const { filter, value } = req.query;
+  let query;
+
+  if (!filter || !value) {
+    query = Family.find();
+  } else {
+    query = Family.find()
+      .where(filter)
+      .equals(value);
+  }
+
+  query
+    .exec()
+    .then(families => {
+      res.status(200).json({ families });
+    })
+    .catch(err => {
+      res.status(500).json({
+        message: err,
+      });
+    });
+});
+
 module.exports = routes;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -6,6 +6,9 @@ const mongoose = require('mongoose');
 const Donor = require('../models/donor');
 const Family = require('../models/family');
 const Wishlist = require('../models/wishlist');
+
+const donorController = require('../controllers/donorController');
+
 mongoose.connect('mongodb://localhost/aaf');
 
 // Configure app to use bodyParser()
@@ -190,5 +193,12 @@ routes.get('/families', (req, res) => {
       });
   }
 });
+
+// This route will only accept 0 query params
+routes.get('/donors', donorController.showAll);
+
+// Accepts one param and one filter only
+// Returns array of donors matching
+routes.get('/donors/:filter', donorController.filterBySingleValue);
 
 module.exports = routes;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -197,7 +197,8 @@ routes.get('/families', (req, res) => {
 // This route will only accept 0 query params
 routes.get('/donors', donorController.showAll);
 
-// Accepts one param and one filter only
+// Accepts one param and one query only
+// eg /donors/_id?value=123
 // Returns array of donors matching
 routes.get('/donors/:filter', donorController.filterBySingleValue);
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -149,8 +149,6 @@ routes.get('/wishlist/:familyId', (req, res) => {
 routes.get('/families', (req, res) => {
   const { filter, value } = req.query;
   const queryKeys = Object.keys(req.query);
-  console.log(`query: ${req.query}`);
-  console.log(`querykeys: ${queryKeys}`);
 
   if (queryKeys.length === 0) {
     const query = Family.find();
@@ -168,12 +166,12 @@ routes.get('/families', (req, res) => {
   } else if (queryKeys.length !== 2) {
     // Throw 400 if incorrect number of parameters received
     res.status(400).json({
-      message: `Received ${queryKeys.length} parameters but expected 2.`,
+      message: `Received ${queryKeys.length} parameter(s) but expected 2.`,
     });
   } else if (!filter || !value) {
     // Throw 400 if there are queries that are not filter/value
     res.status(400).json({
-      message: 'Invalid parameters supplied',
+      message: 'Invalid parameters supplied.',
     });
   } else {
     const query = Family.find({ filter: value });


### PR DESCRIPTION
This PR adds the routes `api/donors` and `/api/donors/:filter`.

To show all donors, make a GET request to `api/donors` with no query fields.
To filter by one field:
GET: `/donors/_id?value=123 // Returns array of donors matching or empty array if no matches`

