### PR TITLE
AAF-136 Update ecmaVersion to 2018 and change to babel-eslint as the …

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
+  "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": 2017,
+    "ecmaVersion": 2018,
     "sourceType": "module",
     "ecmaFeatures": {
       "jsx": true
@@ -12,9 +13,7 @@
     "jest": true
   },
   "plugins": ["react", "prettier"],
-  "extends": [
-    "plugin:prettier/recommended"
-  ],
+  "extends": ["plugin:prettier/recommended"],
   "rules": {
     "linebreak-style": ["error", "unix"]
   }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,7 +3,6 @@
   "trailingComma": "es5",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
-  "parser": "babylon",
   "semi": true,
   "arrowParens": "always"
 }


### PR DESCRIPTION
…parser for eslint/prettier, allowing us to use latest JS features

One feature that wasn't working was declaring state as a property of the class:

```
class MyClass extends Component {
  state = { someState: false } // threw eslint errors
}
```

Fixes #136